### PR TITLE
common practice for package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,9 @@
   "private": true,
   "scripts": {
     "lint": "eslint --ext .js,.vue src",
-    "test": "echo \"No test specified\" && exit 0"
+    "test": "echo \"No test specified\" && exit 0",
+    "start": "quasar dev",
+    "build": "quasar build"
   },
   "dependencies": {
     "@quasar/extras": "^1.0.0",


### PR DESCRIPTION
common practice for node is to include all running scripts in the package.json

so instead of "quasar dev", you can just "npm start"
also quasar (and similar packages like eslint, babel, etc..) are not allways in your PATH.
npm injects them.